### PR TITLE
Group tools with the same language root together

### DIFF
--- a/components/tools/listPage/AlternateToolsList/index.ts
+++ b/components/tools/listPage/AlternateToolsList/index.ts
@@ -1,1 +1,0 @@
-export { AlternateToolsList } from './AlternateToolsList';

--- a/components/tools/listPage/AlternativeToolsList/index.ts
+++ b/components/tools/listPage/AlternativeToolsList/index.ts
@@ -1,0 +1,1 @@
+export { AlternativeToolsList } from './AlternativeToolsList';

--- a/components/tools/listPage/index.ts
+++ b/components/tools/listPage/index.ts
@@ -1,6 +1,6 @@
 export * from './LanguageCard';
 export * from './ToolCard';
 export * from './ToolsList';
-export * from './AlternateToolsList';
+export * from './AlternativeToolsList';
 export * from './ToolsSidebar';
 export * from './ListPageComponent';

--- a/components/tools/queries/tools.ts
+++ b/components/tools/queries/tools.ts
@@ -10,7 +10,7 @@ import { Tool } from '../types';
  * @see https://react-query.tanstack.com/guides/query-keys
  */
 export const TOOLS_PREFETCH_KEY = 'tools';
-export const ALTERNATE_TOOLS_PREFETCH_KEY = 'alternate-tools';
+export const ALTERNATE_TOOLS_PREFETCH_KEY = 'alternative-tools';
 
 /**
  * Prepare and prefetch data on server-side, to be ready on client page render
@@ -62,7 +62,7 @@ export function useToolsQueryCount(search: SearchState) {
  *
  * @see https://react-query.tanstack.com/guides/queries
  */
-export function useAlternateToolsQuery(search: SearchState) {
+export function useAlternativeToolsQuery(search: SearchState) {
     //TODO: Filter out current Tool
     // FIXME: Key should contain some SearchState data to avoid cache issues
     return useQuery(ALTERNATE_TOOLS_PREFETCH_KEY, () =>

--- a/pages/tag/[slug].tsx
+++ b/pages/tag/[slug].tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { MainHead, Footer, Navbar, SponsorBanner } from '@components/core';
 import { Main, Panel, Sidebar, Wrapper } from '@components/layout';
-import { LanguageCard, AlternateToolsList, Tool } from '@components/tools';
+import { LanguageCard, AlternativeToolsList, Tool } from '@components/tools';
 import { SearchProvider } from 'context/SearchProvider';
 import { Article, LanguageData, SponsorData } from 'utils/types';
 import { getArticles } from 'utils-api/blog';
@@ -86,7 +86,7 @@ const TagPage: FC<TagProps> = ({ slug, tag, tools, articles, sponsors }) => {
                     </Sidebar>
                     <Panel>
                         <LanguageCard tag={slug} tagData={tag} />
-                        <AlternateToolsList tools={tools} />
+                        <AlternativeToolsList tools={tools} />
                     </Panel>
                 </Main>
             </Wrapper>

--- a/pages/tool/[slug].tsx
+++ b/pages/tool/[slug].tsx
@@ -4,7 +4,7 @@ import { MainHead, Footer, Navbar, SponsorBanner } from '@components/core';
 import { Main, Panel, Wrapper } from '@components/layout';
 import { getTool } from 'utils-api/tools';
 import {
-    AlternateToolsList,
+    AlternativeToolsList,
     Tool,
     ToolInfoCard,
     ToolInfoSidebar,
@@ -62,7 +62,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         ...apiTool,
         id: slug,
     };
-
     const alternativeTools = await getTools();
     let alternatives: Tool[] = [];
     if (alternativeTools) {
@@ -141,7 +140,10 @@ const ToolPage: FC<ToolProps> = ({
                     <ToolInfoSidebar tool={tool} articles={articles} />
                     <Panel>
                         <ToolInfoCard tool={tool} screenshots={screenshots} />
-                        <AlternateToolsList tools={alternatives} />
+                        <AlternativeToolsList
+                            currentTool={tool}
+                            tools={alternatives}
+                        />
                     </Panel>
                 </Main>
             </Wrapper>

--- a/utils/arrays.ts
+++ b/utils/arrays.ts
@@ -2,3 +2,18 @@
 export function containsArray(a: any[], b: any[]) {
     return b.every((v) => a.includes(v));
 }
+
+// check if two arrays are equal. The order of the elements does not matter
+export function arraysEqual(a: any[], b: any[]) {
+    return containsArray(a, b) && containsArray(b, a);
+}
+
+// Remove a key from an array
+// If the key is not found, the original array is returned
+export const arrayDelete = (myArray: string[], key: string): string[] => {
+    const index = myArray.indexOf(key, 0);
+    if (index > -1) {
+        myArray.splice(index, 1);
+    }
+    return myArray;
+};


### PR DESCRIPTION
E.g. C/C++ and JavaScript/TypeScript will be treated as the same
category when suggesting alternative tools.

Also renamed "alternate" to "alternative" everywhere as that's the proper term.