### PR TITLE
Remove cache from getToolsWithVotes to fix sorting

### DIFF
--- a/utils-api/toolsWithVotes.ts
+++ b/utils-api/toolsWithVotes.ts
@@ -1,51 +1,22 @@
-import { isToolsApiData } from 'utils/type-guards';
-import { getCacheManager } from './cache';
+import { isToolsApiData, isVotesApiData } from 'utils/type-guards';
 import { getAllTools } from './tools';
 import { getVotes } from './votes';
 
-const cacheDataManager = getCacheManager();
-
 export const getToolsWithVotes = async () => {
-    const cacheKey = 'tools_votes_data';
+    const data = await getAllTools();
+    const votes = await getVotes();
 
-    try {
-        // Get data from cache
-        const cacheResponse = await cacheDataManager.get(cacheKey);
-        if (!cacheResponse) {
-            console.log(
-                `Cache data for: ${cacheKey} does not exist - calling API`,
-            );
-            // Call API and refresh cache
-            const data = await getAllTools();
-            const votes = await getVotes();
-
-            if (!data || !votes) {
-                console.error('Error loading tools with votes data');
-                await cacheDataManager.del(cacheKey);
-                return null;
-            }
-            Object.keys(data).forEach((toolId) => {
-                const key = `toolsyaml${toolId.toString()}`;
-                data[toolId].votes = votes[key]?.sum || 0;
-                data[toolId].upVotes = votes[key]?.upVotes || 0;
-                data[toolId].downVotes = votes[key]?.downVotes || 0;
-            });
-
-            const hours = Number(process.env.API_CACHE_TTL) || 24;
-            await cacheDataManager.set(cacheKey, data, hours * 60 * 60);
-
-            return data;
-        }
-
-        if (!isToolsApiData(cacheResponse)) {
-            console.error('Error loading tools with votes data');
-            await cacheDataManager.del(cacheKey);
-            return null;
-        }
-        return cacheResponse;
-    } catch (e) {
-        console.error('Error occurred: ', JSON.stringify(e));
-        await cacheDataManager.del(cacheKey);
+    if (!isToolsApiData(data) || !isVotesApiData(votes)) {
+        console.error('Error loading tools with votes data');
         return null;
     }
+
+    Object.keys(data).forEach((toolId) => {
+        const key = `toolsyaml${toolId.toString()}`;
+        data[toolId].votes = votes[key]?.sum || 0;
+        data[toolId].upVotes = votes[key]?.upVotes || 0;
+        data[toolId].downVotes = votes[key]?.downVotes || 0;
+    });
+
+    return data;
 };


### PR DESCRIPTION
Sorting is currently not working correctly after a user votes on a tool, since this function was caching its response for 24H and not updating votes when called again.

This PR removes the caching functionality from `getToolsWithVotes` since Vote data should not be cached and the tools data cache is already managed by another function which is called within this one. 