### PR TITLE
Fix ToolCard clickable layout

### DIFF
--- a/components/elements/ImageWithFallback/ImageWithFallback.tsx
+++ b/components/elements/ImageWithFallback/ImageWithFallback.tsx
@@ -13,7 +13,7 @@ const ImageWithFallback = (props: ImageWithFallbackProps) => {
         <Image
             {...rest}
             src={imgSrc}
-            alt=""
+            alt={props.alt}
             onError={() => {
                 setImgSrc(fallbackSrc);
             }}

--- a/components/elements/TagList/TagList.module.css
+++ b/components/elements/TagList/TagList.module.css
@@ -1,7 +1,6 @@
 .tagList {
     display: flex;
     list-style: none;
-    margin: 20px 0;
     padding: 0;
     flex-wrap: wrap;
     column-gap: 8px;

--- a/components/elements/TagList/TagList.module.css
+++ b/components/elements/TagList/TagList.module.css
@@ -6,6 +6,7 @@
     flex-wrap: wrap;
     column-gap: 8px;
     row-gap: 8px;
+    align-items: center;
 }
 
 .tag {
@@ -13,6 +14,10 @@
     background: #345779;
     padding: 4px 8px;
     border-radius: 6px;
+}
+
+.tag:hover {
+    background: #3c6995;
 }
 
 .tag a {
@@ -36,4 +41,9 @@
 
 .showMore {
     cursor: pointer;
+    font-size: 14px;
+    color: #58a6ff;
+    height: 20px;
+    font-family: Roboto-Light;
+    text-decoration: underline;
 }

--- a/components/elements/TagList/TagList.tsx
+++ b/components/elements/TagList/TagList.tsx
@@ -25,36 +25,30 @@ const TagList: FC<TagListProps> = ({ languageTags, otherTags, className }) => {
         setShowAllTags((prevShowAllTags) => !prevShowAllTags);
     };
 
-    const toggleTag = (event: any, tagType: TagTypes) => {
+    const handleClick = (event: any, tagType: TagTypes) => {
         const tag = event?.target.innerText;
-        const currentTags = search[tagType];
 
-        if (Array.isArray(currentTags)) {
-            if (currentTags.includes(tag)) {
-                setSearch({
-                    ...search,
-                    [tagType]: currentTags.filter((l: string) => l !== tag),
-                });
+        let currValue = search[tagType] || [];
+        if (!Array.isArray(currValue)) {
+            currValue = [currValue];
+        }
+        if (currValue.length) {
+            const index = currValue.indexOf(tag);
+            if (index > -1) {
+                currValue.splice(index, 1);
             } else {
-                setSearch({
-                    ...search,
-                    [tagType]: [...currentTags, tag],
-                });
+                currValue.push(tag);
             }
         } else {
-            setSearch({
-                ...search,
-                [tagType]: [tag],
-            });
+            currValue.push(tag);
         }
 
-        routerPush(
-            `/tools?${objectToQueryString(search as Record<string, any>)}`,
-            undefined,
-            {
-                shallow: true,
-            },
-        );
+        const newState = { ...search, [tagType]: currValue };
+        setSearch(newState);
+        // Update query params in router
+        routerPush(`/tools?${objectToQueryString(newState)}`, undefined, {
+            shallow: true,
+        });
     };
 
     const combinedTags = [
@@ -80,7 +74,7 @@ const TagList: FC<TagListProps> = ({ languageTags, otherTags, className }) => {
                         [`${styles.highlight}`]: search[type]?.includes(tag),
                     })}
                     key={`${tag}-${index}`}>
-                    <a onClick={(e) => toggleTag(e, type)}>
+                    <a onClick={(e) => handleClick(e, type)}>
                         <Image
                             className={styles.tagIcon}
                             src={tagIconPath(tag)}
@@ -96,8 +90,8 @@ const TagList: FC<TagListProps> = ({ languageTags, otherTags, className }) => {
             {combinedTags.length > NUM_TAGS && (
                 <li
                     onClick={toggleShowAllTags}
-                    className={classNames(styles.tag, styles.showMore)}>
-                    {showAllTags ? 'Show less' : 'Show more'}
+                    className={classNames(styles.showMore)}>
+                    {showAllTags ? 'less' : 'more'}
                 </li>
             )}
         </ul>

--- a/components/layout/Card/Card.tsx
+++ b/components/layout/Card/Card.tsx
@@ -5,10 +5,15 @@ import styles from './Card.module.css';
 export interface CardProps {
     className?: string;
     children?: React.ReactNode[] | React.ReactNode;
+    onClick?: any;
 }
 
-const Card: FC<CardProps> = ({ className, children }) => {
-    return <div className={classNames(styles.card, className)}>{children}</div>;
+const Card: FC<CardProps> = ({ className, children, onClick }) => {
+    return (
+        <div className={classNames(styles.card, className)} onClick={onClick}>
+            {children}
+        </div>
+    );
 };
 
 export default Card;

--- a/components/tools/listPage/LanguageCard/LanguageCard.module.css
+++ b/components/tools/listPage/LanguageCard/LanguageCard.module.css
@@ -2,12 +2,14 @@
     margin: 0 0 30px 0;
     padding: 20px;
     border: 1px solid #486a8b;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
 }
 
 .languageCardHeader {
     display: flex;
     align-items: center;
-    margin: 0 0 20px 0;
 }
 
 .languageName {
@@ -30,7 +32,6 @@
 }
 
 .description {
-    margin: 15px 0;
     line-height: 20px;
 }
 

--- a/components/tools/listPage/ToolCard/ToolCard.module.css
+++ b/components/tools/listPage/ToolCard/ToolCard.module.css
@@ -42,6 +42,8 @@
     cursor: pointer;
 }
 
+.descriptionWrapper{}
+
 .description {
     font-size: 14px;
     overflow-wrap: anywhere;

--- a/components/tools/listPage/ToolCard/ToolCard.module.css
+++ b/components/tools/listPage/ToolCard/ToolCard.module.css
@@ -3,6 +3,11 @@
     width: 100%;
     margin: 0 0 30px 0;
     padding: 0;
+    cursor: pointer;
+}
+
+.toolCardWrapper:hover{
+    border-color: #58a6ff;
 }
 
 .votes {
@@ -13,7 +18,7 @@
     flex-direction: column;
     align-items: center;
     gap: 10px;
-    min-width: 55px;
+    width: 55px;
 }
 
 .info {
@@ -64,7 +69,7 @@
 
 .toolLink {
     text-underline-offset: 4px;
-    text-decoration: underline;
+    /* text-decoration: underline; */
 }
 
 .toolType {

--- a/components/tools/listPage/ToolCard/ToolCard.module.css
+++ b/components/tools/listPage/ToolCard/ToolCard.module.css
@@ -6,7 +6,7 @@
     cursor: pointer;
 }
 
-.toolCardWrapper:hover{
+.toolCardWrapper:hover {
     border-color: #58a6ff;
 }
 
@@ -25,15 +25,16 @@
     flex-grow: 1;
     flex-basis: 0;
     padding: 15px;
+    display: flex;
+    gap: 30px;
+    flex-direction: column;
 }
 
 .clickOut {
-    background-color: #3c6993;
     width: 80px;
     background-image: url('/assets/icons/general/chevron.png');
     background-repeat: no-repeat;
     background-position: center;
-    opacity: 0.5;
 }
 
 .clickOut:hover {
@@ -42,7 +43,6 @@
 }
 
 .description {
-    margin: 16px 0;
     font-size: 14px;
     overflow-wrap: anywhere;
 }
@@ -52,7 +52,6 @@
 }
 
 .toolMeta {
-    margin: 20px 0 0 0;
     padding: 0;
     list-style: none;
     display: flex;
@@ -69,7 +68,7 @@
 
 .toolLink {
     text-underline-offset: 4px;
-    /* text-decoration: underline; */
+    display: flex;
 }
 
 .toolType {
@@ -80,6 +79,7 @@
     display: inline;
     vertical-align: top;
     padding-right: 5px;
+    font-size: 20px;
 }
 
 .languageLink {
@@ -87,4 +87,40 @@
     vertical-align: top;
     font-size: 13px !important;
     color: #ffffff;
+}
+
+.clickOut {
+    display: none;
+}
+
+@media only screen and (max-width: 900px) {
+    .toolCardWrapper {
+        flex-direction: column-reverse;
+    }
+
+    .info {
+        padding: 20px;
+    }
+
+    .clickOut {
+        display: unset;
+        border: 1px solid #486a8b;
+        border-radius: 10px;
+        width: 50px;
+    }
+
+    .votes {
+        width: 100%;
+        border-radius: 0 0 6px 6px;
+        align-items: unset;
+        padding: 10px;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+
+    .voteWidget {
+        height: unset !important;
+        width: 100px !important;
+        flex-direction: row !important;
+    }
 }

--- a/components/tools/listPage/ToolCard/ToolCard.tsx
+++ b/components/tools/listPage/ToolCard/ToolCard.tsx
@@ -12,6 +12,7 @@ import { VoteWidget } from '@components/widgets';
 import { deCamelString } from 'utils/strings';
 import { isSponsor } from 'utils/sponsor';
 import { useIntersection } from 'hooks';
+import router from 'next/router';
 
 export interface ToolCardProps {
     tool: Tool;
@@ -28,9 +29,19 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
         ? deCamelString(tool.languages[0])
         : 'Multi-Language';
 
+    // Route to tool page
+    const handleElementClick = (e: any) => {
+        // Check element click by class name
+        if (e.target.className === styles.info) {
+            e.stopPropagation();
+            router.push(`/tool/${tool.id}`);
+            return;
+        }
+    };
+
     // FIXME: Get language tag from name to work as href, some languages have different names then their tag
     return (
-        <Card className={styles.toolCardWrapper}>
+        <Card className={styles.toolCardWrapper} onClick={handleElementClick}>
             <div className={styles.votes} ref={votesRef}>
                 {isVotesInViewport && <VoteWidget toolId={tool.id} />}
             </div>
@@ -129,12 +140,12 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
                     )}
                 </ul>
             </div>
-            <Link
+            {/* <Link
                 passHref={true}
                 className={styles.clickOut}
                 href={`/tool/${tool.id}`}>
                 <div className={styles.clickOut} />
-            </Link>
+            </Link> */}
         </Card>
     );
 };

--- a/components/tools/listPage/ToolCard/ToolCard.tsx
+++ b/components/tools/listPage/ToolCard/ToolCard.tsx
@@ -20,7 +20,6 @@ export interface ToolCardProps {
 
 const ToolCard: FC<ToolCardProps> = ({ tool }) => {
     const votesRef = useRef(null);
-    const isVotesInViewport = useIntersection(votesRef);
 
     const isSingleLanguage = tool.languages.length === 1;
 
@@ -39,11 +38,16 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
         }
     };
 
-    // FIXME: Get language tag from name to work as href, some languages have different names then their tag
     return (
         <Card className={styles.toolCardWrapper} onClick={handleElementClick}>
             <div className={styles.votes} ref={votesRef}>
-                {isVotesInViewport && <VoteWidget toolId={tool.id} />}
+                <VoteWidget toolId={tool.id} />
+                <Link
+                    passHref={true}
+                    className={styles.clickOut}
+                    href={`/tool/${tool.id}`}>
+                    <div className={styles.clickOut} />
+                </Link>
             </div>
             <div className={styles.info}>
                 <Link href={`/tool/${tool.id}`}>
@@ -51,17 +55,17 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
                         <Heading level={3} className={styles.toolName}>
                             {tool.name}
                         </Heading>
+                        {isSponsor(tool.id) && (
+                            <Image
+                                className={styles.sponsorLogo}
+                                height="18px"
+                                width="18px"
+                                src="/assets/icons/general/sponsor.svg"
+                                alt="Sponsor"
+                            />
+                        )}
                     </a>
                 </Link>
-                {isSponsor(tool.id) && (
-                    <Image
-                        className={styles.sponsorLogo}
-                        height="18px"
-                        width="18px"
-                        src="/assets/icons/general/sponsor.svg"
-                        alt="Sponsor"
-                    />
-                )}
 
                 <ReactMarkdown className={styles.description}>
                     {tool.description || ''}
@@ -140,12 +144,6 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
                     )}
                 </ul>
             </div>
-            {/* <Link
-                passHref={true}
-                className={styles.clickOut}
-                href={`/tool/${tool.id}`}>
-                <div className={styles.clickOut} />
-            </Link> */}
         </Card>
     );
 };

--- a/components/tools/listPage/ToolCard/ToolCard.tsx
+++ b/components/tools/listPage/ToolCard/ToolCard.tsx
@@ -37,7 +37,6 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
     // Route to tool page
     const handleElementClick = (e: any) => {
         // Check element click by class name
-        console.log(e.target.className);
         if (CLICKOUT_CLASSES.includes(e.target.className)) {
             e.stopPropagation();
             router.push(`/tool/${tool.id}`);

--- a/components/tools/listPage/ToolCard/ToolCard.tsx
+++ b/components/tools/listPage/ToolCard/ToolCard.tsx
@@ -18,6 +18,12 @@ export interface ToolCardProps {
     tool: Tool;
 }
 
+const CLICKOUT_CLASSES = [
+    styles.info,
+    styles.toolMeta,
+    styles.descriptionWrapper,
+];
+
 const ToolCard: FC<ToolCardProps> = ({ tool }) => {
     const votesRef = useRef(null);
 
@@ -31,7 +37,8 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
     // Route to tool page
     const handleElementClick = (e: any) => {
         // Check element click by class name
-        if (e.target.className === styles.info) {
+        console.log(e.target.className);
+        if (CLICKOUT_CLASSES.includes(e.target.className)) {
             e.stopPropagation();
             router.push(`/tool/${tool.id}`);
             return;
@@ -39,7 +46,7 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
     };
 
     return (
-        <Card className={styles.toolCardWrapper} onClick={handleElementClick}>
+        <Card className={styles.toolCardWrapper}>
             <div className={styles.votes} ref={votesRef}>
                 <VoteWidget toolId={tool.id} />
                 <Link
@@ -49,7 +56,7 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
                     <div className={styles.clickOut} />
                 </Link>
             </div>
-            <div className={styles.info}>
+            <div className={styles.info} onClick={handleElementClick}>
                 <Link href={`/tool/${tool.id}`}>
                     <a className={styles.toolLink}>
                         <Heading level={3} className={styles.toolName}>
@@ -67,9 +74,12 @@ const ToolCard: FC<ToolCardProps> = ({ tool }) => {
                     </a>
                 </Link>
 
-                <ReactMarkdown className={styles.description}>
-                    {tool.description || ''}
-                </ReactMarkdown>
+                <div className={styles.descriptionWrapper}>
+                    <ReactMarkdown className={styles.description}>
+                        {tool.description || ''}
+                    </ReactMarkdown>
+                </div>
+
                 <TagList languageTags={tool.languages} otherTags={tool.other} />
 
                 <ul className={styles.toolMeta}>

--- a/components/tools/toolPage/ToolInfoCard/ToolInfoCard.module.css
+++ b/components/tools/toolPage/ToolInfoCard/ToolInfoCard.module.css
@@ -21,6 +21,16 @@
     position: relative;
     padding: 30px;
     flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+}
+
+.cardHeader {
+    display: flex;
+    gap: 15px;
+    flex-direction: row-reverse;
+    justify-content: space-between;
 }
 
 .toolName {
@@ -29,7 +39,6 @@
 }
 
 .description {
-    margin: 30px 0;
     line-height: 20px;
 }
 
@@ -100,5 +109,35 @@
 
     .info {
         padding: 15px;
+    }
+
+    .languageCardWrapper {
+        flex-direction: column-reverse;
+    }
+
+    .info {
+        padding: 20px;
+    }
+
+    .clickOut {
+        display: unset;
+        border: 1px solid #486a8b;
+        border-radius: 10px;
+        width: 50px;
+    }
+
+    .votes {
+        width: 100%;
+        border-radius: 0 0 6px 6px;
+        align-items: unset;
+        padding: 10px;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+
+    .voteWidget {
+        height: unset !important;
+        width: 100px !important;
+        flex-direction: row !important;
     }
 }

--- a/components/widgets/VoteWidget/VoteWidget.module.css
+++ b/components/widgets/VoteWidget/VoteWidget.module.css
@@ -76,5 +76,35 @@
 .upvotePercentage {
     opacity: 0.65;
     font-size: 12px;
-    text-align: center;
+}
+
+@media only screen and (max-width: 900px) {
+    .primary {
+        width: 120px;
+        min-width: 120px;
+        height: 30px;
+        border: 1px solid #486a8b;
+        border-radius: 10px;
+        display: flex;
+        justify-content: center;
+        flex-direction: row;
+    }
+
+    .upvotePercentage {
+        opacity: 1;
+        line-height: 30px;
+    }
+
+    .primary .votes {
+        border-left: 1px solid #486a8b;
+        border-right: 1px solid #486a8b;
+    }
+
+    .primary .loading {
+        flex: 1;
+    }
+
+    .primary .voteBtn {
+        background-size: 14px;
+    }
 }

--- a/components/widgets/VoteWidget/VoteWidget.tsx
+++ b/components/widgets/VoteWidget/VoteWidget.tsx
@@ -27,7 +27,6 @@ const VoteWidget: FC<VoteWidgetProps> = ({
         useToolVotesQuery(toolId);
 
     const votesData = data?.data;
-    console.log('Got votes data', votesData);
 
     useEffect(() => {
         const localVote = localStorage.getItem(`vote-${toolId}`);

--- a/context/SearchProvider.tsx
+++ b/context/SearchProvider.tsx
@@ -4,7 +4,6 @@
 
 import { useRouter } from 'next/router';
 import { createContext, FC, useContext, useState } from 'react';
-import { MainHead } from '@components/core';
 
 export type SetSearchStateAction = Dispatch<React.SetStateAction<SearchState>>;
 
@@ -55,6 +54,13 @@ export interface SearchProviderProps {
 
 export const SearchProvider: FC<SearchProviderProps> = ({ children }) => {
     const router = useRouter();
+    // Convert values in query to array
+    Object.keys(router.query).forEach((key) => {
+        if (!Array.isArray(router.query[key])) {
+            router.query[key] = [router.query[key]];
+        }
+    });
+
     const [search, setSearch] = useState(router.query);
 
     return (

--- a/pages/api/tool/[toolId].ts
+++ b/pages/api/tool/[toolId].ts
@@ -29,7 +29,6 @@ export default async function handler(
         });
         return res;
     }
-    console.log(`Getting votes for ${toolId}`);
     const { votes, upVotes, downVotes, upvotePercentage } = await getToolVotes(
         toolId.toString(),
     );

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -20,7 +20,7 @@ import { FilterOption } from '@components/tools/listPage/ToolsSidebar/FilterCard
 import { getArticlesPreviews } from 'utils-api/blog';
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-    const sponsors = getSponsors();
+    const sponsors = await getSponsors();
     const articles = await getArticlesPreviews();
     const { data: languages } = await fetchLanguages();
     const { data: others } = await fetchOthers();
@@ -62,7 +62,7 @@ const ToolsPage: FC<ToolsProps> = ({
         'Find the best SAST tool for your project. All CLI tools and services for JavaScript, Python, Java, C, PHP, Ruby, and more.';
 
     return (
-        <html lang="en">
+        <>
             <MainHead title={title} description={description} />
             <SearchProvider>
                 <Navbar />
@@ -75,11 +75,10 @@ const ToolsPage: FC<ToolsProps> = ({
                         />
                     </Main>
                 </Wrapper>
-
                 <SponsorBanner sponsors={sponsors} />
                 <Footer />
             </SearchProvider>
-        </html>
+        </>
     );
 };
 

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -15,7 +15,7 @@ export const objectToQueryString = (query) => {
                         `${encodeURIComponent(key)}=${paramValue}`,
                     );
                 });
-            } else {
+            } else if (key !== 'slug') {
                 const paramValue = encodeURIComponent(value);
                 paramStrings.push(`${encodeURIComponent(key)}=${paramValue}`);
             }


### PR DESCRIPTION
This PR addresses an issue with the ToolCard click action not being too clear.

- The ToolCard is now clickable as an element with cursor and hover effect.
- Votes in ToolCard now has a fixed width to avoid layout shift on load
- TagList fixed click routing and more/less button layout


**Current Card Layout:**

_Desktop ToolCard_
![Screenshot 2024-04-13 181433](https://github.com/analysis-tools-dev/website-next/assets/28806343/eca7322b-c34d-4c11-bb55-b0f18ad92f82)

_Mobile ToolCard_
![Screenshot 2024-04-13 181447](https://github.com/analysis-tools-dev/website-next/assets/28806343/aaf837b2-89ec-404c-88a5-1bef6113a57e)



**New Card Layout:**

_Desktop ToolCard_
![Screenshot 2024-04-13 181500](https://github.com/analysis-tools-dev/website-next/assets/28806343/59cbb535-f3c6-47f0-8be4-4c83e2c36c80)


_Mobile ToolCard_
![Screenshot 2024-04-13 181511](https://github.com/analysis-tools-dev/website-next/assets/28806343/6929b9b8-95e9-4bbd-bf94-850108f11411)
